### PR TITLE
fix: init command for other option

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -99,7 +99,7 @@ export async function init() {
     })
     configSourcePath = path.join(stubs, 'next/tailwind.config.next.stub')
     themeProvider = path.join(stubs, 'next/theme-provider.stub')
-    providers = path.join(stubs, 'next/providerns.stub')
+    providers = path.join(stubs, 'next/providers.stub')
   }
 
   const spinner = ora(`Initializing Justd...`).start()


### PR DESCRIPTION
- Fixed file name for next providers stub

Currently, the command `npx justd-cli@latest init` does not work for vite projects (others option) because it cannot find the provider stub