### PR TITLE
fix: stop git check spinner

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -29,6 +29,7 @@ export async function init(flags: { force?: boolean }) {
       info(`You may use the ${highlight("--force")} flag to silence this warning and perform the initialization anyway.`)
       process.exit(1)
     }
+    checkingGit.stop() // stop spinner
   }
 
   const spinner = ora(`Initializing.`).start()


### PR DESCRIPTION
When repository is clean, the git check spinner wasn't being stopped, causing the initialization process to get stuck at "Checking" stage and preventing users from proceeding to the next steps.
![image](https://github.com/user-attachments/assets/5a31ad71-6a6f-4708-b4c7-d761a0bcba2b)
